### PR TITLE
Bugfix/solve hand aiguille build issue on watchos

### DIFF
--- a/Sources/Rings/HandAiguille.swift
+++ b/Sources/Rings/HandAiguille.swift
@@ -159,11 +159,19 @@ struct AppleStyleHandPreview: View {
             }
             HStack {
                 Spacer(minLength: 10)
+                #if os(watchOS)
+                Picker("Time Unit", selection: $unit) {
+                    Text("hour").tag(TimeUnit.hour)
+                    Text("minute").tag(TimeUnit.minute)
+                    Text("second").tag(TimeUnit.second)
+                }
+                #else
                 Picker("Time Unit", selection: $unit) {
                     Text("hour").tag(TimeUnit.hour)
                     Text("minute").tag(TimeUnit.minute)
                     Text("second").tag(TimeUnit.second)
                 }.pickerStyle(SegmentedPickerStyle())
+                #endif
                 Spacer(minLength: 10)
             }
             Toggle("show blueprint", isOn: $showBlueprint)

--- a/Sources/Rings/HandAiguille.swift
+++ b/Sources/Rings/HandAiguille.swift
@@ -91,13 +91,13 @@ extension HandAiguille {
         return result
     }
     
-    func blueprint(_ isOn:Bool = true) -> Self {
+    public func blueprint(_ isOn:Bool = true) -> Self {
         setProperty { tmp in
             tmp.showBlueprint = isOn
         }
     }
     
-    func handBackground<Background>(_ background: Background) -> Self where Background : View {
+    public func handBackground<Background>(_ background: Background) -> Self where Background : View {
         setProperty{ tmp in
             tmp.handBackground = AnyView(background)
         }


### PR DESCRIPTION
1. Fix build fail on watchOS -- due to unavailable Picker Style on watch OS
2. Publishing HandAiguille extensions to setup HandAiguille features.