### PR TITLE
Refactor/change floating to binary floating point protocol

### DIFF
--- a/Sources/Rings/ClockIndex.swift
+++ b/Sources/Rings/ClockIndex.swift
@@ -26,12 +26,12 @@ public let classicHourStyle: StrokeStyle = StrokeStyle(lineWidth: 5.0, lineCap: 
 public let classicMinStyle: StrokeStyle = StrokeStyle(lineWidth: 2.0, lineCap: CGLineCap.butt, lineJoin: CGLineJoin.miter, miterLimit: 0.0, dash: [0, CGFloat.pi*100/36], dashPhase: 0.0)
 
 public extension StrokeStyle {
-    func hourStyle(with radius: CGFloat) -> Self {
-        StrokeStyle(lineWidth: self.lineWidth, lineCap: self.lineCap, lineJoin: self.lineJoin, miterLimit: self.miterLimit, dash: [0, CGFloat.pi*radius/6], dashPhase: self.dashPhase)
+    func hourStyle<T: BinaryFloatingPoint>(with radius: T) -> Self {
+        StrokeStyle(lineWidth: self.lineWidth, lineCap: self.lineCap, lineJoin: self.lineJoin, miterLimit: self.miterLimit, dash: [0, CGFloat.pi*CGFloat(radius)/6], dashPhase: self.dashPhase)
     }
     
-    func minuteStyle(with radius: CGFloat) -> Self {
-        StrokeStyle(lineWidth: self.lineWidth, lineCap: self.lineCap, lineJoin: self.lineJoin, miterLimit: self.miterLimit, dash: [0, CGFloat.pi*radius/36], dashPhase: self.dashPhase)
+    func minuteStyle<T: BinaryFloatingPoint>(with radius: T) -> Self {
+        StrokeStyle(lineWidth: self.lineWidth, lineCap: self.lineCap, lineJoin: self.lineJoin, miterLimit: self.miterLimit, dash: [0, CGFloat.pi*CGFloat(radius)/36], dashPhase: self.dashPhase)
     }
 }
 
@@ -106,9 +106,9 @@ extension ClockIndex {
         return result
     }
     
-    public func radius(_ r: CGFloat) -> Self {
+    public func radius<T: BinaryFloatingPoint>(_ r: T) -> Self {
         setProperty { tmp in
-            tmp.radius = r
+            tmp.radius = CGFloat(r)
         }
     }
     public func showBlueprint(_ show: Bool) -> Self {
@@ -124,9 +124,9 @@ extension ClockIndex {
         }
     }
     
-    public func hourIndexRadius(_ r: CGFloat) -> Self {
+    public func hourIndexRadius<T: BinaryFloatingPoint>(_ r: T) -> Self {
         setProperty { tmp in
-            tmp.hourIndexRadius = r
+            tmp.hourIndexRadius = CGFloat(r)
         }
     }
     
@@ -137,9 +137,9 @@ extension ClockIndex {
         }
     }
     
-    public func minIndexRadius(_ r: CGFloat) -> Self {
+    public func minIndexRadius<T: BinaryFloatingPoint>(_ r: T) -> Self {
         setProperty { tmp in
-            tmp.minIndexRadius = r
+            tmp.minIndexRadius = CGFloat(r)
         }
     }
     

--- a/Sources/Rings/HandAiguille.swift
+++ b/Sources/Rings/HandAiguille.swift
@@ -24,9 +24,9 @@ extension TimeUnit {
     }
 }
 
-public struct HandAiguille<Content: View> : View {
+public struct HandAiguille<Content: View, T: BinaryFloatingPoint> : View {
     
-    @Binding private var time: Double
+    @Binding private var time: T
     @State private var angle: Angle = Angle()
     
     private let content: () -> Content
@@ -37,9 +37,9 @@ public struct HandAiguille<Content: View> : View {
     private var showBlueprint: Bool = false
     private var handBackground: AnyView = AnyView(Color.clear)
     
-    public init(size: CGSize = CGSize(width: 3.0, height: 50.0), offset: CGFloat = 1.5, time: Binding<Double> = .constant(0), unit: TimeUnit = .second, @ViewBuilder content: @escaping () -> Content) {
+    public init(size: CGSize = CGSize(width: 3.0, height: 50.0), offset: T = 1.5, time: Binding<T> = .constant(0), unit: TimeUnit = .second, @ViewBuilder content: @escaping () -> Content) {
         self.handSize = size
-        self.offset = offset
+        self.offset = CGFloat(offset)
         _time = time
         timeUnit = unit
         self.content = content
@@ -69,15 +69,16 @@ public struct HandAiguille<Content: View> : View {
         }
     }
     
-    private func angleOfTime(_ time: Double) -> Angle {
+    private func angleOfTime(_ time: T) -> Angle {
+        let t = Double(time)
         switch timeUnit {
         case .hour:
-            let t = time.truncatingRemainder(dividingBy: 12.0)
-            return Angle(degrees: t * 30.0)
+            let r = t.truncatingRemainder(dividingBy: 12.0)
+            return Angle(degrees: r * 30.0)
         case .minute, .second:
-            let t =
-                time.truncatingRemainder(dividingBy: 60.0)
-            return Angle(degrees: t * 6.0)
+            let r =
+                t.truncatingRemainder(dividingBy: 60.0)
+            return Angle(degrees: r * 6.0)
         }
     }
 }
@@ -107,7 +108,7 @@ extension HandAiguille {
 public struct HandFactory {
     public static let standard = HandFactory()
     private let rectRatio: CGFloat = 0.2
-    public func makeAppleWatchStyleHand(size: CGSize = CGSize(width: 4.0, height: 60.0), timeProvider: Binding<Double>, unit: TimeUnit = .second) -> some View {
+    public func makeAppleWatchStyleHand<T: BinaryFloatingPoint>(size: CGSize = CGSize(width: 4.0, height: 60.0), timeProvider: Binding<T>, unit: TimeUnit = .second) -> some View {
         HandAiguille(size: size, offset: 1.5, time: timeProvider, unit: unit) {
             VStack(spacing: 0) {
                 Capsule().stroke().frame(width: size.width)
@@ -119,7 +120,7 @@ public struct HandFactory {
 }
 
 struct AppleStyleHandPreview: View {
-    @State var emulateTime: Double = 0.0
+    @State var emulateTime: CGFloat = 0.0
     @State var showBlueprint: Bool = false
     @State var offset: CGFloat = 1.5
     @State var unit: TimeUnit = .second

--- a/Sources/Rings/RingText.swift
+++ b/Sources/Rings/RingText.swift
@@ -44,9 +44,9 @@ public struct RingText : View {
     
     @State private var sizes: [CGSize] = []
     private var showBlueprint: Bool = false
-    
-    public init(radius: Double, words: [String], color: Color = Color.white, upsideDown: Bool = false, reversed: Bool = false, begin: CGAngle = CGAngle.zero, end: CGAngle? = nil) {
-        self.radius = radius
+
+    public init<T: BinaryFloatingPoint>(radius: T, words: [String], color: Color = Color.white, upsideDown: Bool = false, reversed: Bool = false, begin: CGAngle = CGAngle.zero, end: CGAngle? = nil) {
+        self.radius = Double(radius)
         self.textColor = color
         self.textUpsideDown = upsideDown
         self.textReversed = reversed
@@ -68,7 +68,7 @@ public struct RingText : View {
         textPoints = _createTextPoints()
     }
     
-    public init(radius: Double, text: String, color: Color = Color.white, upsideDown: Bool = false, reversed: Bool = false, begin: CGAngle = CGAngle.zero) {
+    public init<T: BinaryFloatingPoint>(radius: T, text: String, color: Color = Color.white, upsideDown: Bool = false, reversed: Bool = false, begin: CGAngle = CGAngle.zero) {
         self.init(radius: radius, words: [text], color: color, upsideDown: upsideDown, reversed: reversed, begin: begin)
     }
     
@@ -218,7 +218,7 @@ struct RingTextPreviewWrapper: View {
                 }
                 ZStack {
                     RingText(radius: 40.0, words: ["a23", "b56", "c89"], reversed: true).showBlueprint(blueprint)
-                    RingText(radius: 80, words: ["1234567890"]).showBlueprint(blueprint)
+                    RingText(radius: 80.0, words: ["1234567890"]).showBlueprint(blueprint)
                 }
                 VStack {
                     ZStack {


### PR DESCRIPTION
Use generic type conform to BinaryFloatingPointer to instead of CGFloat and Double.
For reducing casting statements.