### PR TITLE
Refactor/redesign knob layer with result builder

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,8 @@ let package = Package(
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(name: "Common",
-                dependencies: []),
+                dependencies: [],
+                exclude: ["PropertyWrapper/Clamping.md"]),
         .target(
             name: "Rings",
             dependencies: ["CoreGraphicsExtension", "Common", "ArchimedeanSpiral"],
@@ -33,7 +34,8 @@ let package = Package(
                       "ClockIndex.md",
                       "ArchimedeanSpiralText.md",
                       "HandAiguille.md",
-                      "SphericText.md"]),
+                      "SphericText.md",
+                      "Knob.md"]),
         .testTarget(
             name: "RingsTests",
             dependencies: ["Rings",

--- a/Sources/Rings/Knob.md
+++ b/Sources/Rings/Knob.md
@@ -8,12 +8,13 @@
 
 ```swift
     // Baisc Knob drawing value along the circumference.
-    @State knobValue : Double                       // default range: 0.0...1.0
-    Knob($knobValue)                                // Create a Knob with default mapping(LinearMapping)
-        .addLayer(ArcKnobLayer()                    // Add ArcKnobLayer to draw circumference.
-                    .arcWidth(10.0)
-                    .arcColor(.blue.opacity(0.7)))
-        .frame(width: 100.0, height: 100.0)
+    @State knobValue : Double               // default range: 0.0...1.0
+    Knob($knobValue) { value, mapping in    // Create a Knob with default mapping(LinearMapping)
+        ArcKnobLayer()                      // Add ArcKnobLayer to draw circumference.
+            .mappingValue(value, with: mapping) // setup value and mapping
+            .arcWidth(10.0)
+            .arcColor(.blue.opacity(0.7))
+    }.frame(width: 100.0, height: 100.0)    // setup knob size
 ```
 <img src="https://user-images.githubusercontent.com/1284944/120065862-1d15bc80-c0a6-11eb-876f-687db7b35d00.gif" alt="drawing" width="200"/>
 
@@ -21,15 +22,16 @@
 
 ```swift
     // A Knob drawing value along circular track. 
-    @State knobValue : Double                       // default range: 0.0...1.0.
-    Knob($knobValue)                                // Create a Knob with default mapping(LinearMapping)
-        .addLayer(RingKnobLayer()                   // Add RingKnobLayer as the track.
-                    .ringWidth(10.0)
-                    .ringColor(.red.opacity(0.5)))
-        .addLayer(ArcKnobLayer()                    // Add ArcKnobLayer to draw circumference.
-                    .arcWidth(10.0)
-                    .arcColor(.blue.opacity(0.7)))
-        .frame(width: 100.0, height: 100.0)
+    @State knobValue : Double               // default range: 0.0...1.0.
+    Knob($knobValue) { value, mapping in    // Create a Knob with default mapping(LinearMapping)
+        RingKnobLayer()                     // Add RingKnobLayer as the track. It has no need to setup value and mapping on RingKnobLayer.
+            .ringWidth(10.0)
+            .ringColor(.red.opacity(0.5))
+        ArcKnobLayer()                      // Add ArcKnobLayer to draw circumference.
+            .mappingValue(value, with: mapping)
+            .arcWidth(10.0)
+            .arcColor(.blue.opacity(0.7))
+    }.frame(width: 100.0, height: 100.0)
 ```
 <img src="https://user-images.githubusercontent.com/1284944/120066040-2bb0a380-c0a7-11eb-865e-e4f2220ffead.gif" alt="drawing" width="200"/>
 
@@ -38,9 +40,10 @@
 ```swift
     // A Knob with rotate image
     @State knobValue : Double                       // default range: 0.0...1.0, the range of knob value depends on mapping object.
-    Knob($knobValue)
-        .addLayer(ImageKnobLayer(Image("SimpleKnob")))
-        .frame(width: 150, height: 150)    
+    Knob($knobValue) { value, mapping in
+        ImageKnobLayer(Image("SimpleKnob"))
+            .mappingValue(value, with: mapping)
+    }.frame(width: 150, height: 150)    
 ```
 <img src="https://user-images.githubusercontent.com/1284944/120066082-61ee2300-c0a7-11eb-97e5-4a64b0bd4e8e.gif" alt="drawing" width="200"/>
 

--- a/Sources/Rings/Knob.swift
+++ b/Sources/Rings/Knob.swift
@@ -152,7 +152,7 @@ public struct Knob: View {
 }
 
 extension Knob : Adjustable {
-    public func addLayer<L>(_ layer: L) -> Self where L : KnobLayer {
+    public func addLayer<L>(_ layer: L) -> Self where L : AngularLayer {
         setProperty { tmp in
             tmp.layers.append(AnyKnobLayer(layer))
         }

--- a/Sources/Rings/Knob.swift
+++ b/Sources/Rings/Knob.swift
@@ -53,9 +53,27 @@ extension CGVector {
     }
 }
 
-public struct Knob: View {
-    private var layers: [AnyKnobLayer]  = []
-    
+extension GeometryProxy {
+    var width : CGFloat {
+        get {
+            self.size.width
+        }
+    }
+    var height: CGFloat {
+        get {
+            self.size.height
+        }
+    }
+    var localCenter: CGPoint {
+        get {
+            CGPoint(x: width/2.0, y: height/2.0)
+        }
+    }
+}
+
+public struct Knob<Content: View>: View {
+    private var contentBuilder: (Double, KnobMapping)->Content
+
     private var mappingObj: KnobMapping
     
     @Binding var value: Double
@@ -68,26 +86,28 @@ public struct Knob: View {
     @State var startVector: CGVector = .zero
     @State private var startValue: Double = .nan
     
-    public init<F: BinaryFloatingPoint>(_ value: Binding<F>, _ mapping: KnobMapping = LinearMapping()) {
+    public init<F: BinaryFloatingPoint>(_ value: Binding<F>, _ mapping: KnobMapping = LinearMapping(), @AngularLayerBuilder _ content: @escaping (Double, KnobMapping)->Content) {
         _value = Binding<Double>(get: {
             Double(value.wrappedValue)
         }, set: { v in
             value.wrappedValue = F(v)
         })
         mappingObj = mapping
+        contentBuilder = content
     }
+    
     public var body: some View {
         GeometryReader { geo in
-            let center = CGPoint(x: geo.size.width/2, y: geo.size.height/2)
-            let radius = min(geo.size.width, geo.size.height)/2.0
+            let center = geo.localCenter
+            let radius = min(geo.width, geo.height)/2.0
             
             let pt = CGPoint(x: center.x + currentVector.dx, y: center.y - currentVector.dy)
             let startPt = CGPoint(x: center.x + startVector.dx, y: center.y - startVector.dy)
-            ZStack {
-                ForEach(layers.indices) { index in
-                    layers[index].degreeRange(mappingObj.degreeRange).degree(mappingObj.degree(from: value)).view.frame(width: geo.size.width, height: geo.size.height, alignment: .center)
+            ZStack(alignment: .center){
+                VStack {
+                    contentBuilder(value, mappingObj).frame(width: geo.size.width, height: geo.size.height, alignment: .center)
                 }
-                Group {
+                if blueprint {
                     Path { p in
                         p.move(to: CGPoint(x: center.x - radius, y: center.y))
                         p.addLine(to: CGPoint(x: center.x + radius, y: center.y))
@@ -103,9 +123,9 @@ public struct Knob: View {
                         p.move(to: center)
                         p.addLine(to: startPt)
                     }.stroke(Color.red.opacity(0.5))
-                }.if(!blueprint) { content in
-                    content.hidden()
                 }
+                
+                
             }.contentShape(Circle()).gesture(DragGesture().onChanged({ value in
                 if(currentVector != CGVector.zero) {
                     if(startValue.isNaN) {
@@ -152,12 +172,7 @@ public struct Knob: View {
 }
 
 extension Knob : Adjustable {
-    public func addLayer<L>(_ layer: L) -> Self where L : AngularLayer {
-        setProperty { tmp in
-            tmp.layers.append(AnyKnobLayer(layer))
-        }
-    }
-    
+   
     public func mapping<T: KnobMapping>(with mapping: T) -> Self {
         setProperty { tmp in
             tmp.mappingObj = mapping
@@ -183,13 +198,26 @@ struct KnobDemo: View {
             Spacer(minLength: 40)
             HStack {
                 VStack {
-                    Knob($valueContiune).addLayer(RingKnobLayer().ringColor(Gradient(colors: [.red, .blue, .blue, .blue, .blue, .blue, .red])).ringWidth(ringWidth)).addLayer(ArcKnobLayer().arcWidth(arcWidth)).blueprint(showBlueprint)
+                    Knob($valueContiune) { value, mapping in
+                        RingKnobLayer()
+                            .mappingValue(value, with: mapping)
+                            .color {
+                                Color.red
+                                Color.blue
+                                Color.yellow
+                            }
+                        ArcKnobLayer()
+                            .mappingValue(value, with: mapping)
+                            .arcColor(.red)
+                    }.blueprint(showBlueprint)
                     Slider(value: $valueContiune, in: 0.0...1.0) {
                         Text(String(format: "value: %.2f", valueContiune))
                     }
                 }
                 VStack {
-                    Knob($valueSegmented).addLayer(RingKnobLayer().ringColor(Gradient(colors: [.blue, .red, .red, .red, .red, .red, .blue])).ringWidth(ringWidth)).addLayer(ArcKnobLayer().arcWidth(arcWidth)).blueprint(showBlueprint).mapping(with: SegmentMapping().stops([KnobStop(0.0, -215.0), KnobStop(1.0, 45.0), KnobStop(0.5, -90.0), KnobStop(0.2, 0.0), KnobStop(0.8, -180.0), KnobStop(0.3, -135)]))
+                    Knob($valueSegmented) { value, mapping in
+                        RingKnobLayer()
+                    }.blueprint(showBlueprint)
                     Slider(value: $valueSegmented, in: 0.0...1.0, step: 0.1) {
                         Text(String(format: "value: %.2f", valueSegmented))
                     }

--- a/Sources/Rings/KnobComponents/Layers/AngularLayer.swift
+++ b/Sources/Rings/KnobComponents/Layers/AngularLayer.swift
@@ -87,48 +87,73 @@ extension ClosedRange where Bound:BinaryFloatingPoint {
 }
 
 @resultBuilder struct AngularLayerBuilder {
+    
     static func buildBlock() -> EmptyView {
         EmptyView()
+    }
+    
+    static func buildFinalResult(_ component: EmptyView) -> EmptyView {
+        return component
     }
     
     static func buildBlock<L: AngularLayer>(_ layer:L) -> L.Body {
         layer.body
     }
+    
+    static func buildFinalResult<V: View>(_ component: V) -> V {
+        return component
+    }
 }
 
-
 extension AngularLayerBuilder {
-    static func buildBlock<L0: AngularLayer, L1: AngularLayer>(_ layer0: L0, _ layer1: L1) -> ZStack<TupleView<(L0.Body, L1.Body)>> {
+    
+    static func buildFinalResult<L0: AngularLayer, L1: AngularLayer>(_ component: (L0, L1)) -> ZStack<TupleView<(L0.Body, L1.Body)>> {
         return ZStack {
-            layer0.body
-            layer1.body
+            component.0.body
+            component.1.body
         }
     }
     
-    static func buildBlock<L0: AngularLayer, L1: AngularLayer, L2: AngularLayer>(_ layer0: L0, _ layer1: L1, _ layer2: L2) -> ZStack<TupleView<(L0.Body, L1.Body, L2.Body)>> {
+    static func buildBlock<L0: AngularLayer, L1: AngularLayer>(_ layer0: L0, _ layer1: L1) -> (L0, L1) {
+        return (layer0, layer1)
+    }
+    
+    static func buildFinalResult<L0: AngularLayer, L1: AngularLayer, L2: AngularLayer>(_ component: (L0, L1, L2)) -> ZStack<TupleView<(L0.Body, L1.Body, L2.Body)>> {
         return ZStack {
-            layer0.body
-            layer1.body
-            layer2.body
+            component.0.body
+            component.1.body
+            component.2.body
         }
     }
     
-    static func buildBlock<L0: AngularLayer, L1: AngularLayer, L2: AngularLayer, L3: AngularLayer>(_ layer0: L0, _ layer1: L1, _ layer2: L2, _ layer3: L3) -> ZStack<TupleView<(L0.Body, L1.Body, L2.Body, L3.Body)>> {
+    static func buildBlock<L0: AngularLayer, L1: AngularLayer, L2: AngularLayer>(_ layer0: L0, _ layer1: L1, _ layer2: L2) -> (L0, L1, L2) {
+        return (layer0, layer1, layer2)
+    }
+    
+    static func buildFinalResult<L0: AngularLayer, L1: AngularLayer, L2: AngularLayer, L3: AngularLayer>(_ component: (L0,L1,L2,L3)) -> ZStack<TupleView<(L0.Body, L1.Body, L2.Body, L3.Body)>> {
         return ZStack {
-            layer0.body
-            layer1.body
-            layer2.body
-            layer3.body
+            component.0.body
+            component.1.body
+            component.2.body
+            component.3.body
         }
     }
     
-    static func buildBlock<L0: AngularLayer, L1: AngularLayer, L2: AngularLayer, L3: AngularLayer, L4: AngularLayer>(_ layer0: L0, _ layer1: L1, _ layer2: L2, _ layer3: L3, _ layer4: L4) -> ZStack<TupleView<(L0.Body, L1.Body, L2.Body, L3.Body, L4.Body)>> {
+    static func buildBlock<L0: AngularLayer, L1: AngularLayer, L2: AngularLayer, L3: AngularLayer>(_ layer0: L0, _ layer1: L1, _ layer2: L2, _ layer3: L3) -> (L0, L1, L2, L3) {
+        return (layer0, layer1, layer2, layer3)
+    }
+    
+    static func buildFinalResult<L0: AngularLayer, L1: AngularLayer, L2: AngularLayer, L3: AngularLayer, L4: AngularLayer>(_ component: (L0,L1,L2,L3,L4)) -> ZStack<TupleView<(L0.Body, L1.Body, L2.Body, L3.Body, L4.Body)>> {
         return ZStack {
-            layer0.body
-            layer1.body
-            layer2.body
-            layer3.body
-            layer4.body
+            component.0.body
+            component.1.body
+            component.2.body
+            component.3.body
+            component.4.body
         }
+    }
+    
+    static func buildBlock<L0: AngularLayer, L1: AngularLayer, L2: AngularLayer, L3: AngularLayer, L4: AngularLayer>(_ layer0: L0, _ layer1: L1, _ layer2: L2, _ layer3: L3, _ layer4: L4) -> (L0, L1, L2, L3, L4) {
+        return (layer0, layer1, layer2, layer3, layer4)
     }
 }

--- a/Sources/Rings/KnobComponents/Layers/AngularLayer.swift
+++ b/Sources/Rings/KnobComponents/Layers/AngularLayer.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-public protocol KnobLayer {
+public protocol AngularLayer {
     var isFixed: Bool { get set }
     /// It's a workground to define property wrapper to protocol
     ///
@@ -49,8 +49,8 @@ public protocol KnobLayer {
 }
 
 /// Type eraser for KnobLayer
-public struct AnyKnobLayer: KnobLayer {
-    var rawLayer: KnobLayer
+public struct AnyKnobLayer: AngularLayer {
+    var rawLayer: AngularLayer
     public var isFixed: Bool {
         get {
             return rawLayer.isFixed
@@ -84,12 +84,12 @@ public struct AnyKnobLayer: KnobLayer {
         }
     }
     
-    public init<T>(_ knobLayer: T) where T: KnobLayer {
+    public init<T>(_ knobLayer: T) where T: AngularLayer {
         self.rawLayer = knobLayer
     }
 }
 
-extension KnobLayer {
+extension AngularLayer {
     func setBaseProperty(_ setBlock: (_ text: inout Self) -> Void) -> Self {
         let result = _setProperty(content: self) { (tmp :inout Self) in
             setBlock(&tmp)

--- a/Sources/Rings/KnobComponents/Layers/AngularLayer.swift
+++ b/Sources/Rings/KnobComponents/Layers/AngularLayer.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 public protocol AngularLayer {
+    associatedtype Body : View
+    
     var isFixed: Bool { get set }
     /// It's a workground to define property wrapper to protocol
     ///
@@ -43,50 +45,10 @@ public protocol AngularLayer {
     /// ```
     ///  KnobLayer requires degreeRange for AnyKnobLayer, since it cannot access $degree from KnobLayer protocol directly.
     ///
-    var degreeRange: ClosedRange<Double> { get set }
     var degree: Double { get set }
-    var view: AnyView { get }
-}
+    var degreeRange: ClosedRange<Double> { get set }
 
-/// Type eraser for KnobLayer
-public struct AnyKnobLayer: AngularLayer {
-    var rawLayer: AngularLayer
-    public var isFixed: Bool {
-        get {
-            return rawLayer.isFixed
-        }
-        set {
-            rawLayer.isFixed = newValue
-        }
-    }
-    
-    public var degreeRange: ClosedRange<Double> {
-        get {
-            return rawLayer.degreeRange
-        }
-        set {
-            rawLayer.degreeRange = newValue
-        }
-    }
-    
-    public var degree: Double {
-        get {
-            return rawLayer.degree
-        }
-        set {
-            rawLayer.degree = newValue
-        }
-    }
-    
-    public var view: AnyView {
-        get {
-            rawLayer.view
-        }
-    }
-    
-    public init<T>(_ knobLayer: T) where T: AngularLayer {
-        self.rawLayer = knobLayer
-    }
+    @ViewBuilder var body: Self.Body { get }
 }
 
 extension AngularLayer {
@@ -109,10 +71,64 @@ extension AngularLayer {
             tmp.degreeRange = range.toDoubleRange()
         }
     }
+    
+    public func mappingValue<F>(_ value: F, with mapping:KnobMapping) -> Self where F:BinaryFloatingPoint {
+        setBaseProperty { tmp in
+            tmp.degreeRange = mapping.degreeRange
+            tmp.degree = mapping.degree(from: Double(value))
+        }
+    }
 }
 
 extension ClosedRange where Bound:BinaryFloatingPoint {
     func toDoubleRange() -> ClosedRange<Double> {
         Double(lowerBound)...Double(upperBound)
+    }
+}
+
+@resultBuilder struct AngularLayerBuilder {
+    static func buildBlock() -> EmptyView {
+        EmptyView()
+    }
+    
+    static func buildBlock<L: AngularLayer>(_ layer:L) -> L.Body {
+        layer.body
+    }
+}
+
+
+extension AngularLayerBuilder {
+    static func buildBlock<L0: AngularLayer, L1: AngularLayer>(_ layer0: L0, _ layer1: L1) -> ZStack<TupleView<(L0.Body, L1.Body)>> {
+        return ZStack {
+            layer0.body
+            layer1.body
+        }
+    }
+    
+    static func buildBlock<L0: AngularLayer, L1: AngularLayer, L2: AngularLayer>(_ layer0: L0, _ layer1: L1, _ layer2: L2) -> ZStack<TupleView<(L0.Body, L1.Body, L2.Body)>> {
+        return ZStack {
+            layer0.body
+            layer1.body
+            layer2.body
+        }
+    }
+    
+    static func buildBlock<L0: AngularLayer, L1: AngularLayer, L2: AngularLayer, L3: AngularLayer>(_ layer0: L0, _ layer1: L1, _ layer2: L2, _ layer3: L3) -> ZStack<TupleView<(L0.Body, L1.Body, L2.Body, L3.Body)>> {
+        return ZStack {
+            layer0.body
+            layer1.body
+            layer2.body
+            layer3.body
+        }
+    }
+    
+    static func buildBlock<L0: AngularLayer, L1: AngularLayer, L2: AngularLayer, L3: AngularLayer, L4: AngularLayer>(_ layer0: L0, _ layer1: L1, _ layer2: L2, _ layer3: L3, _ layer4: L4) -> ZStack<TupleView<(L0.Body, L1.Body, L2.Body, L3.Body, L4.Body)>> {
+        return ZStack {
+            layer0.body
+            layer1.body
+            layer2.body
+            layer3.body
+            layer4.body
+        }
     }
 }

--- a/Sources/Rings/KnobComponents/Layers/ArcKnobLayer.swift
+++ b/Sources/Rings/KnobComponents/Layers/ArcKnobLayer.swift
@@ -11,6 +11,7 @@ import Common
 public struct ArcKnobLayer : AngularLayer {
     public var isFixed: Bool = false
     
+    @Clamping(0.0...0.0) public var degree: Double = 120.0
     public var degreeRange: ClosedRange<Double> {
         get {
             $degree
@@ -20,25 +21,22 @@ public struct ArcKnobLayer : AngularLayer {
         }
     }
     
-    @Clamping(0.0...0.0) public var degree: Double = 120.0
     
     private var arcWidth: CGFloat = 5.0
     private var arcColor: Color = .white
     
-    public var view: AnyView {
+    public var body: some View {
         get {
-            AnyView(ZStack {
+            ZStack {
                 GeometryReader { geo in
                     Path { p in
                         let radius = min(geo.size.height, geo.size.width)/2.0 - arcWidth/2.0
                         p.addArc(center: CGPoint(x: geo.size.width/2, y: geo.size.height/2), radius: radius, startAngle: Angle.degrees(degreeRange.lowerBound), endAngle: Angle.degrees(Double(degree)), clockwise: false)
-                    }.stroke(arcColor, lineWidth: arcWidth).opacity(0.5)
+                    }.stroke(arcColor, lineWidth: arcWidth)
                 }
-            })
+            }
         }
     }
-    
-    public init() {}
 }
 
 extension ArcKnobLayer : Adjustable {

--- a/Sources/Rings/KnobComponents/Layers/ArcKnobLayer.swift
+++ b/Sources/Rings/KnobComponents/Layers/ArcKnobLayer.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 import Common
 
-public struct ArcKnobLayer : KnobLayer {
+public struct ArcKnobLayer : AngularLayer {
     public var isFixed: Bool = false
     
     public var degreeRange: ClosedRange<Double> {

--- a/Sources/Rings/KnobComponents/Layers/ImageKnobLayer.swift
+++ b/Sources/Rings/KnobComponents/Layers/ImageKnobLayer.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-public struct ImageKnobLayer : KnobLayer {
+public struct ImageKnobLayer : AngularLayer {
     var image: Image
     public var isFixed: Bool = false
     

--- a/Sources/Rings/KnobComponents/Layers/ImageKnobLayer.swift
+++ b/Sources/Rings/KnobComponents/Layers/ImageKnobLayer.swift
@@ -6,19 +6,20 @@
 //
 
 import SwiftUI
+import Common
 
 public struct ImageKnobLayer : AngularLayer {
     var image: Image
     public var isFixed: Bool = false
     
+    @Clamping(0.0...0.0) public var degree: Double = 0.0
     public var degreeRange: ClosedRange<Double> = 0.0...0.0
-    public var degree: Double = 0.0
     
-    public var view: AnyView {
+    public var body: some View {
         get {
-            AnyView(image.resizable().if(!isFixed, content: { content in
+            image.resizable().if(!isFixed, content: { content in
                 content.rotationEffect(Angle.degrees(Double(degree)))
-            }))
+            })
         }
     }
     

--- a/Sources/Rings/KnobComponents/Layers/RingKnobLayer.swift
+++ b/Sources/Rings/KnobComponents/Layers/RingKnobLayer.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-public struct RingKnobLayer : KnobLayer {
+public struct RingKnobLayer : AngularLayer {
     public var isFixed: Bool = true
     public var degreeRange = 0.0...0.0
     public var degree: Double = 0.0

--- a/Sources/Rings/KnobComponents/Layers/RingKnobLayer.swift
+++ b/Sources/Rings/KnobComponents/Layers/RingKnobLayer.swift
@@ -6,45 +6,48 @@
 //
 
 import SwiftUI
+import Common
+
+@resultBuilder struct RingGradientBuilder {
+    static func buildBlock(_ components: Color...) -> AngularGradient {
+        guard !components.isEmpty else {
+            return AngularGradient(gradient: Gradient(colors: [.white]), center: .center)
+        }
+        
+        var flatColors = components.flatMap { Array(repeating:$0,count:2) }
+        flatColors += [flatColors[0]] // To close angular gradient
+        return AngularGradient(gradient: Gradient(colors: flatColors), center: .center)
+    }
+}
 
 public struct RingKnobLayer : AngularLayer {
     public var isFixed: Bool = true
-    public var degreeRange = 0.0...0.0
-    public var degree: Double = 0.0
     
-    public var view: AnyView {
+    @Clamping(max:0.0, min:0.0) public var degree: Double = 0.0
+    
+    public var degreeRange: ClosedRange<Double> = 0.0...0.0
+    
+    private var gradient: AngularGradient = AngularGradient(gradient: Gradient(colors: [.white]), center: .center)
+    var ringWidth: Double = 5.0
+    
+    public var body: some View {
         get {
-            AnyView(Circle().stroke(ringAngularGradient(), lineWidth: ringWidth).padding(EdgeInsets(top: ringWidth/2.0, leading: ringWidth/2.0, bottom: ringWidth/2.0, trailing: ringWidth/2.0)))
+            Circle().stroke(gradient, lineWidth: CGFloat(ringWidth)).padding(EdgeInsets(top: CGFloat(ringWidth/2.0), leading: CGFloat(ringWidth/2.0), bottom: CGFloat(ringWidth/2.0), trailing: CGFloat(ringWidth/2.0)))
         }
     }
-    
-    private func ringAngularGradient() -> AngularGradient {
-        let gradient = ringGradient ?? Gradient(colors: [ringColor])
-        return AngularGradient(gradient: gradient, center: .center, startAngle: Angle.degrees(degreeRange.lowerBound), endAngle: Angle.degrees(degreeRange.upperBound))
-    }
-    private var ringColor: Color = .white
-    private var ringGradient: Gradient? = nil
-    private var ringWidth: CGFloat = 2.0
-    
-    public init() {}
 }
 
 extension RingKnobLayer : Adjustable {
-    public func ringColor(_ color: Color) -> Self {
-        setProperty { tmp in
-            tmp.ringColor = color
-            tmp.ringGradient = nil
-        }
+    func color(@RingGradientBuilder _ builder: ()->AngularGradient ) -> Self {
+        var tmp = self
+        tmp.gradient = builder()
+        return tmp
     }
-    public func ringColor(_ gradient: Gradient) -> Self {
-        setProperty { tmp in
-            tmp.ringGradient = gradient
-            tmp.ringColor = .clear
-        }
+    
+    func ringWidth<T>(_ width: T) -> Self where T: BinaryFloatingPoint {
+        var tmp = self
+        tmp.ringWidth = Double(width)
+        return tmp
     }
-    public func ringWidth<T>(_ width: T) -> Self where T:BinaryFloatingPoint {
-        setProperty { tmp in
-            tmp.ringWidth = CGFloat(width)
-        }
-    }
+    
 }


### PR DESCRIPTION
Refactor to make Knob support result builder syntax.
It makes the creation of Knob more structured.

Old version:
```swift
    @State var degree = 0.0
    Knob($degree)
        .addLayer(ArcKnobLayer().arcColor().arcWidth())
        .addLayer(RingKnobLayer().ringColor().ringWidth()) // Need write lots of addLayer(), and setup layers with long statements.
```

New version:
```swift
    @State var degree = 0.0
    Knob($degree) { value, mapping in
        ArcKnobLayer().mapping(value, mapping).arcColor().arcWidth()   // Without addLayer, it looks more clear.
        RingKnobLayer().mapping(value, mapping).ringColor().ringWidth()
    }
```