### PR TITLE
Use enum to instead of struct on result builder

### DIFF
--- a/Sources/Rings/KnobComponents/Layers/AngularLayer.swift
+++ b/Sources/Rings/KnobComponents/Layers/AngularLayer.swift
@@ -86,7 +86,8 @@ extension ClosedRange where Bound:BinaryFloatingPoint {
     }
 }
 
-@resultBuilder struct AngularLayerBuilder {
+@resultBuilder
+public enum AngularLayerBuilder {
     
     static func buildBlock() -> EmptyView {
         EmptyView()

--- a/Sources/Rings/KnobComponents/Layers/RingKnobLayer.swift
+++ b/Sources/Rings/KnobComponents/Layers/RingKnobLayer.swift
@@ -8,7 +8,8 @@
 import SwiftUI
 import Common
 
-@resultBuilder struct RingGradientBuilder {
+@resultBuilder
+public enum RingGradientBuilder {
     static func buildBlock(_ components: Color...) -> AngularGradient {
         guard !components.isEmpty else {
             return AngularGradient(gradient: Gradient(colors: [.white]), center: .center)


### PR DESCRIPTION
Refer to https://stackoverflow.com/a/38585994/505763 and https://github.com/raywenderlich/swift-style-guide#constants

Change result builder from struct to enum to avoid unexpected instantiate of result builder.