### PR TITLE
Refactor/remove useless method

### DIFF
--- a/Sources/Rings/HandAiguille.md
+++ b/Sources/Rings/HandAiguille.md
@@ -5,14 +5,15 @@ https://user-images.githubusercontent.com/1284944/117106480-83aeff80-adb2-11eb-8
 
 ### Usage: 
 ```swift
-  // Create empty hand aiguille with default size, and set the hand aiguille background red
+  // Create empty hand aiguille with default size.
+  // When there is no embedded view in hand aiguille, it shows gray rectangle as placeholder.
   HandAiguille() {
-  }.handBackground(Color.red)
+  }
   
   // Create empty hand aiguille with time provider, and specify its time unit.
   @State var hourProvider: Double = 0.0
   HandAiguille(time: $hourProvider, unit: .hour) {
-  }.handBackgroudn(Color.red)
+  }
   
   // Create hand aiguille with Image
   @State var secsProvider: Double = 0.0
@@ -21,5 +22,5 @@ https://user-images.githubusercontent.com/1284944/117106480-83aeff80-adb2-11eb-8
   }
   
   // Create apple watch style hand
-  HandFactory.standard.makeAppleWatchStyleHand(time: $secsProvider)
+  HandFactory.makeAppleWatchStyleHand(time: $secsProvider)
 ```

--- a/Sources/Rings/HandAiguille.swift
+++ b/Sources/Rings/HandAiguille.swift
@@ -35,7 +35,7 @@ public struct HandAiguille<Content: View, T: BinaryFloatingPoint> : View {
     private var timeUnit: TimeUnit
     
     private var showBlueprint: Bool = false
-    private var handBackground: AnyView = AnyView(Color.clear)
+    private var handPlaceholder: Color = .gray
     
     public init(size: CGSize = CGSize(width: 3.0, height: 50.0), offset: T = 1.5, time: Binding<T> = .constant(0), unit: TimeUnit = .second, @ViewBuilder content: @escaping () -> Content) {
         self.handSize = size
@@ -61,7 +61,7 @@ public struct HandAiguille<Content: View, T: BinaryFloatingPoint> : View {
                     p.stroke(Color.blue)
                 }
                 if(content() is EmptyView) {
-                    handBackground.frame(width: handSize.width, height: handSize.height, alignment: .center).offset(y: -yoffset).rotationEffect(angleOfTime(time))
+                    handPlaceholder.frame(width: handSize.width, height: handSize.height, alignment: .center).offset(y: -yoffset).rotationEffect(angleOfTime(time))
                 } else {
                     content().frame(width: handSize.width, height: handSize.height, alignment: .center).offset(y: -yoffset).rotationEffect(angleOfTime(time))
                 }
@@ -95,12 +95,6 @@ extension HandAiguille {
     public func blueprint(_ isOn:Bool = true) -> Self {
         setProperty { tmp in
             tmp.showBlueprint = isOn
-        }
-    }
-    
-    public func handBackground<Background>(_ background: Background) -> Self where Background : View {
-        setProperty{ tmp in
-            tmp.handBackground = AnyView(background)
         }
     }
 }

--- a/Sources/Rings/HandAiguille.swift
+++ b/Sources/Rings/HandAiguille.swift
@@ -99,10 +99,8 @@ extension HandAiguille {
     }
 }
 
-public struct HandFactory {
-    public static let standard = HandFactory()
-    private let rectRatio: CGFloat = 0.2
-    public func makeAppleWatchStyleHand<T: BinaryFloatingPoint>(size: CGSize = CGSize(width: 4.0, height: 60.0), timeProvider: Binding<T>, unit: TimeUnit = .second) -> some View {
+public enum HandFactory {
+    public static func makeAppleWatchStyleHand<T: BinaryFloatingPoint>(size: CGSize = CGSize(width: 4.0, height: 60.0), timeProvider: Binding<T>, unit: TimeUnit = .second) -> some View {
         HandAiguille(size: size, offset: 1.5, time: timeProvider, unit: unit) {
             VStack(spacing: 0) {
                 Capsule().stroke().frame(width: size.width)
@@ -112,7 +110,6 @@ public struct HandFactory {
         }
     }
 }
-
 
 struct RoundedBorder: ViewModifier {
     var cornerRadius:CGFloat = 5
@@ -154,8 +151,8 @@ struct AppleStyleHandPreview: View {
                     }.blueprint(showBlueprint).frame(width: 100, height: 100, alignment: .center)
                 }
                 ZStack {
-                    HandFactory.standard.makeAppleWatchStyleHand(size: CGSize(width: 5.0, height: 80.0),timeProvider: $emulateTime, unit: .hour).frame(width: 120, height: 120, alignment: .center)
-                    HandFactory.standard.makeAppleWatchStyleHand(size: CGSize(width: 4.0, height: 60.0),timeProvider: $emulateTime, unit: .minute).frame(width: 120, height: 120, alignment: .center)
+                    HandFactory.makeAppleWatchStyleHand(size: CGSize(width: 5.0, height: 80.0),timeProvider: $emulateTime, unit: .hour).frame(width: 120, height: 120, alignment: .center)
+                    HandFactory.makeAppleWatchStyleHand(size: CGSize(width: 4.0, height: 60.0),timeProvider: $emulateTime, unit: .minute).frame(width: 120, height: 120, alignment: .center)
                 }
             }
             


### PR DESCRIPTION
1. Remove the setup function handBackground(), because it is rarely used
2. Rename handBackground to handPlaceholder to make the meaning clear.
3. Redefine handPlaceholder to Color rather than AnyView, since there is no need to setup it from outside.
4. Change the Implementation of HandFactory --  declare it as enum rather than public struct
    a. reduce the effort to implement singleton mechanism.
    b. simplify its usage.

5. Update HandAiguille document.