### PR TITLE
Refactor/replace layer builer

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "Rings",
-    platforms: [.macOS(.v10_15), .iOS(.v13), .tvOS(.v13), .watchOS(.v6)],
+    platforms: [.macOS(.v10_15), .iOS(.v14), .tvOS(.v13), .watchOS(.v6)],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
@@ -20,7 +20,8 @@ let package = Package(
         // .package(url: /* package url */, from: "1.0.0"),
         .package(name: "CoreGraphicsExtension", url: "https://github.com/chenhaiteng/CoreGraphicsExtension.git", from: "0.2.0"),
         .package(name: "ArchimedeanSpiral", url: "https://github.com/chenhaiteng/ArchimedeanSpiral.git",  from: "1.0.12"),
-        .package(name: "GradientBuilder", url: "https://github.com/chenhaiteng/GradientBuilder.git", .branch("main"))
+        .package(name: "GradientBuilder", url: "https://github.com/chenhaiteng/GradientBuilder.git", .branch("main")),
+        .package(name: "SequenceBuilder", url: "https://github.com/andtie/SequenceBuilder.git", .branch("main"))
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -30,7 +31,7 @@ let package = Package(
                 exclude: ["PropertyWrapper/Clamping.md"]),
         .target(
             name: "Rings",
-            dependencies: ["CoreGraphicsExtension", "Common", "ArchimedeanSpiral", "GradientBuilder"],
+            dependencies: ["CoreGraphicsExtension", "Common", "ArchimedeanSpiral", "GradientBuilder", "SequenceBuilder"],
             exclude: ["RingText.md",
                       "ClockIndex.md",
                       "ArchimedeanSpiralText.md",

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "Rings",
-    platforms: [.macOS(.v10_15), .iOS(.v14), .tvOS(.v13), .watchOS(.v6)],
+    platforms: [.macOS(.v11), .iOS(.v14), .tvOS(.v13), .watchOS(.v6)],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(

--- a/Sources/Rings/Knob.swift
+++ b/Sources/Rings/Knob.swift
@@ -98,17 +98,6 @@ public struct Knob<Layers:Sequence>: View where Layers.Element: AngularLayer{
         layers = builder()
     }
     
-    //
-    //    public init<F: BinaryFloatingPoint>(_ value: Binding<F>, _ mapping: KnobMapping = LinearMapping(), @AngularLayerBuilder _ content: @escaping (Double, KnobMapping)->Content) {
-    //        _value = Binding<Double>(get: {
-    //            Double(value.wrappedValue)
-    //        }, set: { v in
-    //            value.wrappedValue = F(v)
-    //        })
-    //        mappingObj = mapping
-    //        contentBuilder = content
-    //    }
-    
     public var body: some View {
         GeometryReader { geo in
             let center = geo.localCenter

--- a/Sources/Rings/Knob.swift
+++ b/Sources/Rings/Knob.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import SequenceBuilder
 
 extension CGPoint {
     static func -(left: CGPoint, right: CGPoint) -> CGVector {
@@ -71,9 +72,10 @@ extension GeometryProxy {
     }
 }
 
-public struct Knob<Content: View>: View {
-    private var contentBuilder: (Double, KnobMapping)->Content
-
+public struct Knob<Layers:Sequence>: View where Layers.Element: AngularLayer{
+    //    private var contentBuilder: (Double, KnobMapping)->Content
+    private var layers: Layers
+    
     private var mappingObj: KnobMapping
     
     @Binding var value: Double
@@ -86,15 +88,26 @@ public struct Knob<Content: View>: View {
     @State var startVector: CGVector = .zero
     @State private var startValue: Double = .nan
     
-    public init<F: BinaryFloatingPoint>(_ value: Binding<F>, _ mapping: KnobMapping = LinearMapping(), @AngularLayerBuilder _ content: @escaping (Double, KnobMapping)->Content) {
+    public init<F:BinaryFloatingPoint>(_ value: Binding<F>, _ mapping: KnobMapping = LinearMapping(), @SequenceBuilder _ builder: ()->Layers) {
         _value = Binding<Double>(get: {
             Double(value.wrappedValue)
         }, set: { v in
             value.wrappedValue = F(v)
         })
         mappingObj = mapping
-        contentBuilder = content
+        layers = builder()
     }
+    
+    //
+    //    public init<F: BinaryFloatingPoint>(_ value: Binding<F>, _ mapping: KnobMapping = LinearMapping(), @AngularLayerBuilder _ content: @escaping (Double, KnobMapping)->Content) {
+    //        _value = Binding<Double>(get: {
+    //            Double(value.wrappedValue)
+    //        }, set: { v in
+    //            value.wrappedValue = F(v)
+    //        })
+    //        mappingObj = mapping
+    //        contentBuilder = content
+    //    }
     
     public var body: some View {
         GeometryReader { geo in
@@ -104,9 +117,10 @@ public struct Knob<Content: View>: View {
             let pt = CGPoint(x: center.x + currentVector.dx, y: center.y - currentVector.dy)
             let startPt = CGPoint(x: center.x + startVector.dx, y: center.y - startVector.dy)
             ZStack(alignment: .center){
-                VStack {
-                    contentBuilder(value, mappingObj).frame(width: geo.size.width, height: geo.size.height, alignment: .center)
+                ForEach(sequence: layers) { (index, layer) in
+                    layer.mappingValue(value, with: mappingObj).body.frame(width: geo.size.width, height: geo.size.height, alignment: .center)
                 }
+                
                 if blueprint {
                     Path { p in
                         p.move(to: CGPoint(x: center.x - radius, y: center.y))
@@ -141,14 +155,14 @@ public struct Knob<Content: View>: View {
                     let valueCurrent = KnobGestureRecord.Value(value: self.value, angle: currentVector.angle(shouldAdjust))
                     
                     let valueNext = KnobGestureRecord.Value(angle: nextVector.angle(shouldAdjust))
-                 
+                    
                     if -nextVector.angle(shouldAdjust).degrees > mappingObj.degreeRange.upperBound {
                         return
                     }
                     if -nextVector.angle(shouldAdjust).degrees < mappingObj.degreeRange.lowerBound {
                         return
                     }
-
+                    
                     
                     let record = KnobGestureRecord(start: valueStart, current:valueCurrent, next:valueNext)
                     let newValue = mappingObj.newValue(record)
@@ -172,7 +186,7 @@ public struct Knob<Content: View>: View {
 }
 
 extension Knob : Adjustable {
-   
+    
     public func mapping<T: KnobMapping>(with mapping: T) -> Self {
         setProperty { tmp in
             tmp.mappingObj = mapping
@@ -198,16 +212,14 @@ struct KnobDemo: View {
             Spacer(minLength: 40)
             HStack {
                 VStack {
-                    Knob($valueContiune) { value, mapping in
+                    Knob($valueContiune) {
                         RingKnobLayer()
-                            .mappingValue(value, with: mapping)
                             .color {
                                 Color.red
                                 Color.blue
                                 Color.yellow
                             }
                         ArcKnobLayer()
-                            .mappingValue(value, with: mapping)
                             .arcColor(.red)
                     }.blueprint(showBlueprint)
                     Slider(value: $valueContiune, in: 0.0...1.0) {
@@ -215,9 +227,16 @@ struct KnobDemo: View {
                     }
                 }
                 VStack {
-                    Knob($valueSegmented) { value, mapping in
-                        RingKnobLayer()
-                    }.blueprint(showBlueprint)
+                    Knob($valueSegmented) {
+                        RingKnobLayer().color {
+                            Color.green
+                            Color.yellow
+                            Color.red
+                        }.ringWidth(ringWidth)
+                        ArcKnobLayer()
+                            .arcColor(.red)
+                            .arcWidth(arcWidth)
+                    }.blueprint(showBlueprint).mapping(with: SegmentMapping().stops([KnobStop(0.0, -215.0), KnobStop(1.0, 45.0), KnobStop(0.5, -90.0), KnobStop(0.2, 0.0), KnobStop(0.8, -180.0), KnobStop(0.3, -135)]))
                     Slider(value: $valueSegmented, in: 0.0...1.0, step: 0.1) {
                         Text(String(format: "value: %.2f", valueSegmented))
                     }

--- a/Sources/Rings/KnobComponents/Layers/Either+AngularLayer.swift
+++ b/Sources/Rings/KnobComponents/Layers/Either+AngularLayer.swift
@@ -9,30 +9,67 @@ import SwiftUI
 import SequenceBuilder
 
 extension Either : AngularLayer where Left:AngularLayer, Right: AngularLayer {
+    
     public var isFixed: Bool {
         get {
-            true
+            switch self {
+            case .left(let layer):
+                return layer.isFixed
+            case .right(let layer):
+                return layer.isFixed
+            }
         }
-        set {
-            
+        mutating set {
+            switch self {
+            case .left(var layer):
+                layer.isFixed = newValue
+                self = .left(layer)
+            case .right(var layer):
+                layer.isFixed = newValue
+                self = .right(layer)
+            }
         }
     }
     
     public var degree: Double {
         get {
-            0.0
+            switch self {
+            case .left(let layer):
+                return layer.degree
+            case .right(let layer):
+                return layer.degree
+            }
         }
-        set {
-            
+        mutating set {
+            switch self {
+            case .left(var layer):
+                layer.degree = newValue
+                self = .left(layer)
+            case .right(var layer):
+                layer.degree = newValue
+                self = .right(layer)
+            }
         }
     }
     public var degreeRange: ClosedRange<Double> {
         get {
-            0.0...1.0
+            switch self {
+            case .left(let layer):
+                return layer.degreeRange
+            case .right(let layer):
+                return layer.degreeRange
+            }
         }
         
-        set {
-        
+        mutating set {
+            switch self {
+            case .left(var layer):
+                layer.degreeRange = newValue
+                self = .left(layer)
+            case .right(var layer):
+                layer.degreeRange = newValue
+                self = .right(layer)
+            }
         }
     }
     

--- a/Sources/Rings/KnobComponents/Layers/Either+AngularLayer.swift
+++ b/Sources/Rings/KnobComponents/Layers/Either+AngularLayer.swift
@@ -1,0 +1,44 @@
+//
+//  Either+AngularLayer.swift
+//  
+//
+//  Created by Chen Hai Teng on 8/19/21.
+//
+
+import SwiftUI
+import SequenceBuilder
+
+extension Either : AngularLayer where Left:AngularLayer, Right: AngularLayer {
+    public var isFixed: Bool {
+        get {
+            true
+        }
+        set {
+            
+        }
+    }
+    
+    public var degree: Double {
+        get {
+            0.0
+        }
+        set {
+            
+        }
+    }
+    public var degreeRange: ClosedRange<Double> {
+        get {
+            0.0...1.0
+        }
+        
+        set {
+        
+        }
+    }
+    
+    public var body: Either<Left.Body, Right.Body> {
+        bimap(left: \.body, right: \.body)
+    }
+}
+
+


### PR DESCRIPTION
### Use SequenceBuilder instead of AngularLayerBuilder. 
1. SequenceBuilder has more complete implementation of resultbuilder -- includes if-else, for-each, and availability support.
2. It needs update support platform from macOS 10.15 to 11.0, and iOS 13 to 14.