### PR TITLE
0.6.2

### DIFF
--- a/Sources/Rings/KnobComponents/Layers/GauageNeedleLayer.swift
+++ b/Sources/Rings/KnobComponents/Layers/GauageNeedleLayer.swift
@@ -63,7 +63,9 @@ public struct GauageNeedleLayer<V> : @preconcurrency AngularLayer where V: View 
                 }.offset(x: (anchor.x - geoCenter.x) - contentSize.width/2.0, y: anchor.y - geo.height)
             }.onPreferenceChange(ViewSizeKey.self, perform: { value in
                 if let v = value.first {
-                    contentSize = v
+                    Task { @MainActor in
+                        contentSize = v
+                    }
                 }
             })
         }

--- a/Sources/Rings/RingText.swift
+++ b/Sources/Rings/RingText.swift
@@ -84,7 +84,9 @@ public struct RingText : View, CompatibleForegroundProxy {
                 }
                 
             }.frame(width: geo.size.width, height: geo.size.height, alignment: .center).onPreferenceChange(ViewSizeKey.self, perform: { value in
-                sizes = value
+                Task { @MainActor in
+                    sizes = value
+                }
             })
         }
     }


### PR DESCRIPTION
Fix Xcode 16.2 compatible issue:
- In Xcode 16.2 onPreferenceChange closure become sendable. So it's need to wrap mutable state with `Task { @MainActor in }`